### PR TITLE
feat: Look for current active folder's path if available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,20 @@ export function activate(context: ExtensionContext) {
 
 		// https://stackoverflow.com/questions/39569993/vs-code-extension-get-full-path
 		let rootPath: string = '';
-		if (workspace.workspaceFolders !== undefined) {
+		const activeEditor = window.activeTextEditor;
+
+		if (activeEditor) {
+			// Get the workspace folder for the currently active file
+			const workspaceFolder = workspace.getWorkspaceFolder(activeEditor.document.uri);
+			if (workspaceFolder) {
+				rootPath = workspaceFolder.uri.path;
+			}
+			else {
+				window.showErrorMessage('Fork error: Active file is not in a workspace folder');
+				return;
+			}
+		}
+		else if (workspace.workspaceFolders !== undefined) {
 			rootPath = workspace.workspaceFolders[0].uri.path;
 		}
 		else {


### PR DESCRIPTION
There can be multiple workspace folders in the current workspace, so we'll need to first look for the active workspace folders from the current active editor. Failing which, fallback to the previous flow.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prioritize active editor's workspace folder for `rootPath` in `activate()` in `src/index.ts`, with error handling for missing workspace folders.
> 
>   - **Behavior**:
>     - In `activate()` in `src/index.ts`, prioritize active editor's workspace folder for `rootPath`.
>     - If no active editor, fallback to first workspace folder.
>     - Show error if active file is not in a workspace folder.
>   - **Error Handling**:
>     - Display error message if active file is not in a workspace folder or if no workspace folder is open.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=imyangyong%2Fvscode-extension-fork&utm_source=github&utm_medium=referral)<sup> for 0c9151e1917612751bcd84917a34bae4a1a866cb. You can [customize](https://app.ellipsis.dev/imyangyong/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->